### PR TITLE
Make share on Twitter text actually usable

### DIFF
--- a/layouts/PostLayout.js
+++ b/layouts/PostLayout.js
@@ -9,11 +9,26 @@ import Comments from '@/components/comments'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
 import SocialIcon from '@/components/social-icons'
 
+
 const editUrl = (fileName) => `${siteMetadata.siteRepo}/blob/master/data/blog/${fileName}`
 const discussUrl = (slug) =>
   `https://mobile.twitter.com/search?q=${encodeURIComponent(
     `${siteMetadata.siteUrl}/blog/${slug}`
   )}`
+
+const twitterPostContent = (summary, postUrl) => {
+  // Max characters limit - link (it's always 23, no matter what) - space
+  const TWITTER_MAX_SUMMARY_LENGTH = 280 - 23 - 1;
+
+  // If it fits within the character allowance, leave it alone.
+  // If not, trim it down to the the last occurance of the space
+  // that fits within the bounds, and add ellipsis at the end.
+  const twitterSummary = summary.length > TWITTER_MAX_SUMMARY_LENGTH
+    ? `${summary.slice(0, summary.lastIndexOf(' ', TWITTER_MAX_SUMMARY_LENGTH - 3))}...`
+    : summary;
+
+  return `${twitterSummary} ${postUrl}`;
+}
 
 const postDateTemplate = {
   weekday: 'long',
@@ -125,7 +140,7 @@ export default function PostLayout({ frontMatter, authorDetails, next, prev, chi
                     <div className="flex flex-wrap">
                       <SocialIcon
                         kind="twitter"
-                        href={`https://twitter.com/intent/tweet?text=${summary}`}
+                        href={`https://twitter.com/intent/tweet?text=${twitterPostContent(summary, siteMetadata.siteUrl)}`}
                         size="6"
                       />
                       <SocialIcon


### PR DESCRIPTION
It will now use trimmed summary (or full if it fits) + post url.