### PR TITLE
fix: edit on GitHub main branch name

### DIFF
--- a/layouts/PostLayout.js
+++ b/layouts/PostLayout.js
@@ -9,7 +9,7 @@ import Comments from '@/components/comments'
 import ScrollTopAndComment from '@/components/ScrollTopAndComment'
 import SocialIcon from '@/components/social-icons'
 
-const editUrl = (fileName) => `https://github.com/getsentry/sentry.engineering/edit/main/data/blog/${fileName}`
+const editUrl = (fileName) => `${siteMetadata.siteRepo}/blob/main/data/blog/${fileName}`
 const discussUrl = (slug) =>
   `https://mobile.twitter.com/search?q=${encodeURIComponent(
     `${siteMetadata.siteUrl}/blog/${slug}`


### PR DESCRIPTION
Additionally:

1. Repo must be made public
2. `siteMetadata.siteRepo` has to be set