### PR TITLE
Fix a typo that disabled plugins from generating

### DIFF
--- a/layouts/PostLayout.js
+++ b/layouts/PostLayout.js
@@ -81,8 +81,8 @@ export default function PostLayout({ frontMatter, authorDetails, next, prev, chi
                       {author.avatar && (
                         <Image
                           src={author.avatar}
-                          width="38px"
-                          height="38px"
+                          width="38"
+                          height="38"
                           alt="avatar"
                           className="h-10 w-10 rounded-full"
                         />

--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -61,7 +61,7 @@ export async function getFileBySlug(type, slug) {
     source,
     // mdx imports can be automatically source from the components directory
     cwd: path.join(root, 'components'),
-    xdmOptions(options, frontmatter) {
+    mdxOptions(options, frontmatter) {
       // this is the recommended way to add custom remark/rehype plugins:
       // The syntax might look weird, but it protects you in case we add/remove
       // plugins in the future.


### PR DESCRIPTION
This was caused by mdx-bundler going from 8.0 to 9.2 #neverupgrade

Thanks to @nikolovlazar for finding this and fixing it. 