### PR TITLE
fix(sitemap): Include all posts

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -11,6 +11,8 @@ const siteMetadata = require('../data/siteMetadata')
     'pages/*.tsx',
     'data/blog/**/*.mdx',
     'data/blog/**/*.md',
+    'data/blog/*.mdx',
+    'data/blog/*.md',
     'public/tags/**/*.xml',
     '!pages/_*.js',
     '!pages/_*.tsx',

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -31,9 +31,6 @@ const siteMetadata = require('../data/siteMetadata')
                   if (fm.data.draft) {
                     return
                   }
-                  if (fm.data.canonicalUrl) {
-                    return
-                  }
                 }
                 const path = page
                   .replace('pages/', '/')


### PR DESCRIPTION
The current sitemap only includes 4 blog posts, updating the filter to include all files directly under `data/blog/` folder