### PR TITLE
Remove YouTube Cookies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code Owners file
+/.github/CODEOWNERS @getsentry/security
+
+# Content Security Policy Owner
+/next.config.js @getsentry/security

--- a/data/blog/mobile-the-future-is-declarative.md
+++ b/data/blog/mobile-the-future-is-declarative.md
@@ -51,9 +51,7 @@ public class MainActivity extends Activity {
 
 iOS did have some declarative features, like Auto Layout, UIAppearance, the Objective-C `@property` declarations, KVC collection operators, and Combine, but it still required writing some level of imperative code.
 
-For example, iOS had (and still has) Storyboards. Storyboards is a graphical tool we use to build our UIs. It is actually an XML file under the hood, but the developers almost never touch the XML code itself. Here’s how we added UI elements in our Storyboards, and created references and actions:
-
-<iframe width="100%" height="450" src="https://www.youtube-nocookie.com/embed/pTTpjeSARZw?controls=0" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"></iframe>
+For example, iOS had (and still has) Storyboards. Storyboards is a graphical tool we use to build our UIs. It is actually an XML file under the hood, but the developers almost never touch the XML code itself. Here’s how we added UI elements in our Storyboards, and created references and actions: [iOS Storyboards - YouTube](https://www.youtube.com/watch?v=pTTpjeSARZw)
 
 ## Being declarative
 To refresh our memory, the **imperative** approach is when you provide step-by-step instructions until you achieve the desired UI. The **declarative** approach is when you describe how the final state of the desired UI should look.

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,6 @@ const ContentSecurityPolicy = `
   media-src 'none';
   connect-src *;
   font-src 'self';
-  frame-src www.youtube-nocookie.com;
   worker-src 'self' blob:;
   child-src 'self' blob:;
   report-uri  https://o1.ingest.sentry.io/api/4506633066512384/security/?sentry_key=05f1ed2eb6d2a24f9b00a7147fdef6db;


### PR DESCRIPTION
New cookies are being dropped by `www.youtube-nocookie.com`, removing the iframe entirely and use links instead