### PR TITLE
fix: Self-host JetBrains Mono font for reliable rendering on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@sentry/astro": "^10.47.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.2.2",
@@ -885,6 +886,15 @@
         "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^2.2.0",
         "module-details-from-path": "^1.0.4"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@sentry/astro": "^10.47.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.2.2",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -43,12 +43,6 @@ const footerLinks = [
     <link rel="icon" type="image/png" sizes="16x16" href="/static/favicons/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/static/favicons/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap"
-      rel="stylesheet"
-    />
     <script is:inline>
       (() => {
         try {
@@ -80,7 +74,7 @@ const footerLinks = [
     }
     <slot name="head" />
   </head>
-  <body class="m-0 bg-[#f8f8fb] text-[#1f2430] antialiased font-['JetBrains_Mono',monospace] leading-[1.7] selection:bg-[#6a5fc1] selection:text-white dark:bg-[#0a0a0a] dark:text-[#e0e0e0]">
+  <body class="m-0 bg-[#f8f8fb] text-[#1f2430] antialiased font-mono leading-[1.7] selection:bg-[#6a5fc1] selection:text-white dark:bg-[#0a0a0a] dark:text-[#e0e0e0]">
     <div class="mx-auto max-w-5xl px-6 max-sm:px-4">
       <div class="flex min-h-screen flex-col">
         <header class="sticky top-0 z-100 border-b border-[#dfdfea] bg-[rgba(248,248,251,0.92)] py-5 backdrop-blur-md dark:border-[#222222] dark:bg-[rgba(10,10,10,0.92)]">

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,4 +1,10 @@
 @import "tailwindcss";
+@import "@fontsource-variable/jetbrains-mono";
+@import "@fontsource-variable/jetbrains-mono/wght-italic.css";
 @plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:where(.dark, .dark *));
+
+@theme {
+  --font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}


### PR DESCRIPTION
## Summary
- Replaces Google Fonts CDN with self-hosted JetBrains Mono variable font (`@fontsource-variable/jetbrains-mono`), ensuring reliable font loading on Windows regardless of CDN availability or network restrictions
- Adds a comprehensive fallback font stack (`Consolas`, `ui-monospace`, etc.) so text remains readable even if the primary font fails to load
- Removes external preconnect/stylesheet `<link>` tags and uses Tailwind's `font-mono` utility with a custom `--font-mono` theme variable

## Test plan
- [ ] Verify the site renders correctly with JetBrains Mono on macOS/Linux
- [ ] Verify the site renders correctly on Windows (primary fix target)
- [ ] Verify no Google Fonts CDN requests in the network tab
- [ ] Verify font files are served from the site's own domain (`/_astro/jetbrains-mono-*.woff2`)
- [ ] Simulate font load failure and verify fallback fonts are readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)