### PR TITLE
feat: Add Vercel redirects to blog.sentry.io

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,11 @@
   "buildCommand": "",
   "redirects": [
     {
+      "source": "/blog/from-monkey-patching-to-tracing-channels",
+      "destination": "https://blog.sentry.io/observability-with-tracing-channels",
+      "permanent": true
+    },
+    {
       "source": "/blog/:slug",
       "destination": "https://blog.sentry.io/:slug",
       "permanent": true

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,26 @@
       "permanent": true
     },
     {
+      "source": "/blog/building-a-performant-ios-profiler",
+      "destination": "https://blog.sentry.io/building-an-ios-profiler",
+      "permanent": true
+    },
+    {
+      "source": "/blog/building-sentry-symbolicator",
+      "destination": "https://blog.sentry.io/building-a-sentry-symbolicator",
+      "permanent": true
+    },
+    {
+      "source": "/blog/sentry-points-of-presence-how-we-built-a-distributed-ingestion-infrastructure",
+      "destination": "https://blog.sentry.io/sentry-points-of-presence-how-we-built-a-distributed-ingestion",
+      "permanent": true
+    },
+    {
+      "source": "/blog/understanding-the-performance-impact-of-generated-javascript",
+      "destination": "https://blog.sentry.io/performance-impact-of-generated-javascript",
+      "permanent": true
+    },
+    {
       "source": "/blog/:slug",
       "destination": "https://blog.sentry.io/:slug",
       "permanent": true

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "buildCommand": "",
+  "redirects": [
+    {
+      "source": "/blog/:slug",
+      "destination": "https://blog.sentry.io/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/:path*",
+      "destination": "https://blog.sentry.io/engineering/",
+      "permanent": true
+    }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "buildCommand": "",
   "redirects": [
     {
       "source": "/blog/from-monkey-patching-to-tracing-channels",
@@ -9,6 +8,11 @@
     {
       "source": "/blog/:slug",
       "destination": "https://blog.sentry.io/:slug",
+      "permanent": true
+    },
+    {
+      "source": "/",
+      "destination": "https://blog.sentry.io/engineering/",
       "permanent": true
     },
     {


### PR DESCRIPTION
Redirect individual blog posts to their new location on blog.sentry.io and catch-all remaining paths to the engineering blog index.